### PR TITLE
Fix cross compile builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,7 @@ fn main() -> Result<()> {
     // compile rlemon:
     {
         assert!(Build::new()
+            .target(&env::var("HOST").unwrap())
             .get_compiler()
             .to_command()
             .arg("-o")


### PR DESCRIPTION
This patch forces rlemon build with host compiler instead of target compiler
