### PR TITLE
Remove assert that is triggered for trailing semicolons

### DIFF
--- a/src/lexer/sql/mod.rs
+++ b/src/lexer/sql/mod.rs
@@ -231,7 +231,6 @@ impl<'input> FallibleIterator for Parser<'input> {
             return Err(err);
         }
         let cmd = self.parser.ctx.cmd();
-        assert_ne!(cmd, None);
         Ok(cmd)
     }
 }


### PR DESCRIPTION
SQL string can contain empty statements, which should be ignored. They were correctly handled in the middle of a sequence of statements, but an empty statement at the end of the SQL string (such as `SELECT 1;;` or `;`) triggered an assert.

I don't know this code in depth, so I'm not 100% sure that removing this assert is harmless. I'm happy to rework the PR if the correct solution is different.