### PR TITLE
Improve parser creation formance.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ phf = { version = "0.11", features = ["uncased"] }
 log = "0.4"
 memchr = "2.0"
 fallible-iterator = "0.3"
-smallvec = ">=1.6.1"
 bitflags = "2.0"
 uncased = "0.9"
 indexmap = "2.0"

--- a/third_party/lemon/lempar.rs
+++ b/third_party/lemon/lempar.rs
@@ -174,8 +174,6 @@ pub struct yyStackEntry {
                          ** is the value of the token  */
 }
 
-use smallvec::SmallVec;
-
 /* The state of the parser is completely contained in an instance of
 ** the following structure */
 #[allow(non_camel_case_types)]
@@ -186,7 +184,7 @@ pub struct yyParser<'input> {
     //#[cfg(not(feature = "YYNOERRORRECOVERY"))]
     yyerrcnt: i32, /* Shifts left before out of the error */
 %%                               /* A place to hold %extra_context */
-    yystack: SmallVec<[yyStackEntry; YYSTACKDEPTH]>, /* The parser's stack */
+    yystack: Vec<yyStackEntry>, /* The parser's stack */
 }
 
 use std::cmp::Ordering;
@@ -324,7 +322,7 @@ impl yyParser<'_> {
             yyidx: 0,
             #[cfg(feature = "YYTRACKMAXSTACKDEPTH")]
             yyhwm: 0,
-            yystack: SmallVec::new(),
+            yystack: Vec::new(),
             //#[cfg(not(feature = "YYNOERRORRECOVERY"))]
             yyerrcnt: -1,
 %%               /* Optional %extra_context store */


### PR DESCRIPTION
Hello and sorry for the intrusion but... I was running some benchmark for https://github.com/penberg/limbo and I found out Parser::new was doing a whole bunch of `memmove` due to the stack approach used by SmallVec.  This PR removes SmallVec in favor of Vec as you will see proven as worth it, by the benchmarks you guys have inside `benches/sqlparser_bench.rs`:

This move creates a huge different in Parser::new, and when I say huge, I say a whopping **1444%** difference. SmallVec triggers too many memmoves.

```bash
# With Vec::new()  ------------------------------------------------
     Running benches/sqlparser_bench.rs (target/release/deps/sqlparser_bench-90367034c12b9cef)
sqlparser-rs parsing benchmark/sqlparser::select
                        time:   [257.62 ns 258.12 ns 258.69 ns]
# With SmallVec::new()  ------------------------------------------------

sqlparser-rs parsing benchmark/sqlparser::select
                        time:   [3.9573 µs 3.9604 µs 3.9654 µs]
                        change: [+1443.7% +1449.0% +1453.8%] (p = 0.00 < 0.05)
                        Performance has regressed.
```
