### PR TITLE
Changed yystack from `Vec::new()` to `Vec::with_capacity(YYSTACKDEPTH)`

### DIFF
--- a/third_party/lemon/lemon.c
+++ b/third_party/lemon/lemon.c
@@ -4518,6 +4518,8 @@ void ReportTable(
   print_stack_union(out,lemp,&lineno);
   if( lemp->stacksize ){
     fprintf(out,"const YYSTACKDEPTH: usize = %s;\n",lemp->stacksize);  lineno++;
+  }else{
+    fprintf(out, "const YYSTACKDEPTH: usize = 128;\n"); lineno++;
   }
   if( lemp->errsym && lemp->errsym->useCnt ){
     fprintf(out,"const YYERRORSYMBOL: YYCODETYPE = %d;\n",lemp->errsym->index); lineno++;

--- a/third_party/lemon/lempar.rs
+++ b/third_party/lemon/lempar.rs
@@ -285,7 +285,7 @@ impl yyParser<'_> {
             yyidx: 0,
             #[cfg(feature = "YYTRACKMAXSTACKDEPTH")]
             yyhwm: 0,
-            yystack: Vec::new(),
+            yystack: Vec::with_capacity(YYSTACKDEPTH),
             //#[cfg(not(feature = "YYNOERRORRECOVERY"))]
             yyerrcnt: -1,
 %%               /* Optional %extra_context store */


### PR DESCRIPTION
It is found to be more performant than `Vec::new()` and it also triggers less heap allocations.

Check: https://github.com/gwenn/lemon-rs/issues/74#issuecomment-2515273192 for benchmarks and discussion regarding this.