### PR TITLE
Reduce stack size of Stmt by pushing the most egregious offenders to the heap.

### DIFF
--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -172,7 +172,7 @@ pub enum Stmt {
         /// `ORDER BY`
         order_by: Option<Vec<SortedColumn>>,
         /// `LIMIT`
-        limit: Option<Limit>,
+        limit: Option<Box<Limit>>,
     },
     /// `DETACH DATABASE`: db name
     Detach(Expr), // TODO distinction between DETACH and DETACH DATABASE
@@ -260,7 +260,7 @@ pub enum Stmt {
         /// `ORDER BY`
         order_by: Option<Vec<SortedColumn>>,
         /// `LIMIT`
-        limit: Option<Limit>,
+        limit: Option<Box<Limit>>,
     },
     /// `VACUUM`: database name, into expr
     Vacuum(Option<Name>, Option<Expr>),
@@ -671,7 +671,7 @@ pub struct Select {
     /// `ORDER BY`
     pub order_by: Option<Vec<SortedColumn>>, // ORDER BY term does not match any column in the result set
     /// `LIMIT`
-    pub limit: Option<Limit>,
+    pub limit: Option<Box<Limit>>,
 }
 
 /// `SELECT` body

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -144,7 +144,7 @@ pub enum Stmt {
         /// columns
         columns: Option<Vec<IndexedColumn>>,
         /// query
-        select: Select,
+        select: Box<Select>,
     },
     /// `CREATE VIRTUAL TABLE`
     CreateVirtualTable {
@@ -238,7 +238,7 @@ pub enum Stmt {
     /// `SAVEPOINT`: savepoint name
     Savepoint(Name),
     /// `SELECT`
-    Select(Select),
+    Select(Box<Select>),
     /// `UPDATE`
     Update {
         /// CTE
@@ -352,7 +352,7 @@ pub enum Expr {
         /// `NOT`
         not: bool,
         /// table name
-        rhs: QualifiedName,
+        rhs: Box<QualifiedName>,
         /// table function arguments
         args: Option<Vec<Expr>>,
     },
@@ -477,7 +477,7 @@ impl Expr {
         Self::InTable {
             lhs: Box::new(lhs),
             not,
-            rhs,
+            rhs: Box::new(rhs),
             args,
         }
     }
@@ -1193,7 +1193,7 @@ pub enum CreateTableBody {
         options: TableOptions,
     },
     /// `AS` select
-    AsSelect(Select),
+    AsSelect(Box<Select>),
 }
 
 impl CreateTableBody {
@@ -1520,7 +1520,7 @@ pub struct Limit {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InsertBody {
     /// `SELECT` or `VALUES`
-    Select(Select, Option<Upsert>),
+    Select(Box<Select>, Option<Upsert>),
     /// `DEFAULT VALUES`
     DefaultValues,
 }

--- a/src/parser/parse.y
+++ b/src/parser/parse.y
@@ -127,7 +127,7 @@ create_table_args(A) ::= LP columnlist(C) conslist_opt(X) RP table_option_set(F)
   A = CreateTableBody::columns_and_constraints(C, X, F)?;
 }
 create_table_args(A) ::= AS select(S). {
-  A = CreateTableBody::AsSelect(S);
+  A = CreateTableBody::AsSelect(Box::new(S));
 }
 %type table_option_set {TableOptions}
 %type table_option {TableOptions}
@@ -476,7 +476,7 @@ ifexists(A) ::= .            {A = false;}
 cmd ::= createkw temp(T) VIEW ifnotexists(E) fullname(Y) eidlist_opt(C)
           AS select(S). {
   self.ctx.stmt = Some(Stmt::CreateView{ temporary: T, if_not_exists: E, view_name: Y, columns: C,
-                                         select: S });
+                                         select: Box::new(S) });
 }
 cmd ::= DROP VIEW ifexists(E) fullname(X). {
   self.ctx.stmt = Some(Stmt::DropView{ if_exists: E, view_name: X });
@@ -486,7 +486,7 @@ cmd ::= DROP VIEW ifexists(E) fullname(X). {
 //////////////////////// The SELECT statement /////////////////////////////////
 //
 cmd ::= select(X).  {
-  self.ctx.stmt = Some(Stmt::Select(X));
+  self.ctx.stmt = Some(Stmt::Select(Box::new(X)));
 }
 
 %type select {Select}
@@ -826,7 +826,7 @@ setlist(A) ::= LP idlist(X) RP EQ expr(Y). {
 cmd ::= with(W) insert_cmd(R) INTO xfullname(X) idlist_opt(F) select(S)
         upsert(U). {
   let (upsert, returning) = U;
-  let body = InsertBody::Select(S, upsert);
+  let body = InsertBody::Select(Box::new(S), upsert);
   self.ctx.stmt = Some(Stmt::Insert{ with: W, or_conflict: R, tbl_name: X, columns: F,
                                      body, returning });
 }

--- a/src/parser/parse.y
+++ b/src/parser/parse.y
@@ -737,7 +737,7 @@ groupby_opt(A) ::= GROUP BY nexprlist(X) having_opt(Y). {A = Some(GroupBy{ exprs
 having_opt(A) ::= .                {A = None;}
 having_opt(A) ::= HAVING expr(X).  {A = Some(X);}
 
-%type limit_opt {Option<Limit>}
+%type limit_opt {Option<Box<Limit>>}
 
 // The destructor for limit_opt will never fire in the current grammar.
 // The limit_opt non-terminal only occurs at the end of a single production
@@ -749,11 +749,11 @@ having_opt(A) ::= HAVING expr(X).  {A = Some(X);}
 //%destructor limit_opt {sqlite3ExprDelete(pParse->db, $$);}
 limit_opt(A) ::= .       {A = None;}
 limit_opt(A) ::= LIMIT expr(X).
-                         {A = Some(Limit{ expr: X, offset: None });}
+                         {A = Some(Box::new(Limit{ expr: X, offset: None }));}
 limit_opt(A) ::= LIMIT expr(X) OFFSET expr(Y).
-                         {A = Some(Limit{ expr: X, offset: Some(Y) });}
+                         {A = Some(Box::new(Limit{ expr: X, offset: Some(Y) }));}
 limit_opt(A) ::= LIMIT expr(X) COMMA expr(Y).
-                         {A = Some(Limit{ expr: X, offset: Some(Y) });}
+                         {A = Some(Box::new(Limit{ expr: X, offset: Some(Y) }));}
 
 /////////////////////////// The DELETE statement /////////////////////////////
 //


### PR DESCRIPTION
It's something but not as much as I would have liked. This also shows the limitations of the approach. Context https://github.com/gwenn/lemon-rs/issues/78.

Now

```bash
$ ulimit -S -s 780
$ cargo run --example sql_cmd "CREATE TABLE _procedure(name text primary key, type text, body text)"
```

passes.