### PR TITLE
Lower the stack size further by pushing Limit on the heap.

### DIFF
--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -172,7 +172,7 @@ pub enum Stmt {
         /// `ORDER BY`
         order_by: Option<Vec<SortedColumn>>,
         /// `LIMIT`
-        limit: Option<Limit>,
+        limit: Option<Box<Limit>>,
     },
     /// `DETACH DATABASE`: db name
     Detach(Expr), // TODO distinction between DETACH and DETACH DATABASE
@@ -260,7 +260,7 @@ pub enum Stmt {
         /// `ORDER BY`
         order_by: Option<Vec<SortedColumn>>,
         /// `LIMIT`
-        limit: Option<Limit>,
+        limit: Option<Box<Limit>>,
     },
     /// `VACUUM`: database name, into expr
     Vacuum(Option<Name>, Option<Expr>),
@@ -671,7 +671,7 @@ pub struct Select {
     /// `ORDER BY`
     pub order_by: Option<Vec<SortedColumn>>, // ORDER BY term does not match any column in the result set
     /// `LIMIT`
-    pub limit: Option<Limit>,
+    pub limit: Option<Box<Limit>>,
 }
 
 /// `SELECT` body

--- a/src/parser/parse.y
+++ b/src/parser/parse.y
@@ -737,7 +737,7 @@ groupby_opt(A) ::= GROUP BY nexprlist(X) having_opt(Y). {A = Some(GroupBy{ exprs
 having_opt(A) ::= .                {A = None;}
 having_opt(A) ::= HAVING expr(X).  {A = Some(X);}
 
-%type limit_opt {Option<Limit>}
+%type limit_opt {Option<Box<Limit>>}
 
 // The destructor for limit_opt will never fire in the current grammar.
 // The limit_opt non-terminal only occurs at the end of a single production
@@ -749,11 +749,11 @@ having_opt(A) ::= HAVING expr(X).  {A = Some(X);}
 //%destructor limit_opt {sqlite3ExprDelete(pParse->db, $$);}
 limit_opt(A) ::= .       {A = None;}
 limit_opt(A) ::= LIMIT expr(X).
-                         {A = Some(Limit{ expr: X, offset: None });}
+                         {A = Some(Box::new(Limit{ expr: X, offset: None }));}
 limit_opt(A) ::= LIMIT expr(X) OFFSET expr(Y).
-                         {A = Some(Limit{ expr: X, offset: Some(Y) });}
+                         {A = Some(Box::new(Limit{ expr: X, offset: Some(Y) }));}
 limit_opt(A) ::= LIMIT expr(X) COMMA expr(Y).
-                         {A = Some(Limit{ expr: X, offset: Some(Y) });}
+                         {A = Some(Box::new(Limit{ expr: X, offset: Some(Y) }));}
 
 /////////////////////////// The DELETE statement /////////////////////////////
 //


### PR DESCRIPTION
https://github.com/gwenn/lemon-rs/issues/78

Now

```bash
$ ulimit -S -s 530
$ cargo run --example sql_cmd "CREATE TABLE _procedure(name text primary key, type text, body text)"
```

passes.

Before:

size_of(Cmd) => 592
size_of(Stmt) => 584
size_of(Select) => 648

after:

size_of(Cmd) => 504
size_of(Stmt) => 496
size_of(Select) => 432