### PR TITLE
Accept parsing SET statements with repeated names

### DIFF
--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -1358,7 +1358,40 @@ impl QualifiedName {
     }
 }
 
-/// Ordered set of distinct column names
+/// Ordered vector of column names
+/// Similar to DistictNames but allows repeated names
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Names(Vec<Name>);
+
+impl Names {
+    /// Initialize
+    pub fn new(name: Name) -> Self {
+        let mut dn = Self(Vec::new());
+        dn.0.push(name);
+        dn
+    }
+    /// Single column name
+    pub fn single(name: Name) -> Self {
+        let mut dn = Self(Vec::with_capacity(1));
+        dn.0.push(name);
+        dn
+    }
+    /// Push name
+    pub fn insert(&mut self, name: Name) -> Result<(), ParserError> {
+        self.0.push(name);
+        Ok(())
+    }
+}
+
+impl Deref for Names {
+    type Target = Vec<Name>;
+
+    fn deref(&self) -> &Vec<Name> {
+        &self.0
+    }
+}
+
+/// [`DistinctNames`]! Ordered set of distinct column names
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DistinctNames(IndexSet<Name>);
 
@@ -1384,6 +1417,7 @@ impl DistinctNames {
         Ok(())
     }
 }
+
 impl Deref for DistinctNames {
     type Target = IndexSet<Name>;
 
@@ -1953,7 +1987,7 @@ pub enum InsertBody {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Set {
     /// column name(s)
-    pub col_names: DistinctNames,
+    pub col_names: Names,
     /// expression
     pub expr: Expr,
 }

--- a/src/parser/parse.y
+++ b/src/parser/parse.y
@@ -812,22 +812,28 @@ cmd ::= with(C) UPDATE orconf(R) xfullname(X) indexed_opt(I) SET setlist(Y) from
 }
 %endif
 
+/* Repeatable id list */
+%type reidlist {Names}
 
+reidlist(A) ::= reidlist(A) COMMA nm(Y).
+    {let id = Y; A.insert(id)?;}
+reidlist(A) ::= nm(Y).
+    { A = Names::new(Y); }
 
 %type setlist {Vec<Set>}
 
 setlist(A) ::= setlist(A) COMMA nm(X) EQ expr(Y). {
-  let s = Set{ col_names: DistinctNames::single(X), expr: Y };
+  let s = Set{ col_names: Names::single(X), expr: Y };
   A.push(s);
 }
-setlist(A) ::= setlist(A) COMMA LP idlist(X) RP EQ expr(Y). {
+setlist(A) ::= setlist(A) COMMA LP reidlist(X) RP EQ expr(Y). {
   let s = Set{ col_names: X, expr: Y };
   A.push(s);
 }
 setlist(A) ::= nm(X) EQ expr(Y). {
-  A = vec![Set{ col_names: DistinctNames::single(X), expr: Y }];
+  A = vec![Set{ col_names: Names::single(X), expr: Y }];
 }
-setlist(A) ::= LP idlist(X) RP EQ expr(Y). {
+setlist(A) ::= LP reidlist(X) RP EQ expr(Y). {
   A = vec![Set{ col_names: X, expr: Y }];
 }
 


### PR DESCRIPTION
Closes #89

ex: 
```sql
UPDATE foo SET (a, a) = (1, 2);
```

Hey, awesome project!

I'm not sure if creating a new structure, specially in `parse.y`, is the better way but it's the less intrusive approach I found.